### PR TITLE
Fix http header parsing for values containing ':'

### DIFF
--- a/src/parser/HttpParser.ts
+++ b/src/parser/HttpParser.ts
@@ -136,7 +136,7 @@ export class HttpParser {
       } else {
         if (line !== "" && !PARSE_BODY) {
           let headerKey = line.split(":")[0];
-          let headerValue = line.split(":")[1];
+          let headerValue = line.split(":").slice(1).join(":");
           if (headerKey === "Response-Delay") {
             DELAY = <number>(<unknown>headerValue);
             logger.debug(`Delay Set ${headerValue}`);


### PR DESCRIPTION
# Description

I am trying to mock a request which returns a http 302 redirect response. The mock file looks like this:
```
HTTP/1.1 302 Found
Location: https://foo:8080/abc/efg
```
The current parsing splits the value of the header based on ':' ending up with `location: https`

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Created a mock and checked the response

**Test Configuration**:
* OS: macOS Big Sur
* Node version:  v14.17.1
* NPM Version: 6.14.13
